### PR TITLE
修正SudokuResNet导入路径

### DIFF
--- a/image_processing/image_to_puzzle.py
+++ b/image_processing/image_to_puzzle.py
@@ -2,7 +2,7 @@ import cv2
 import numpy as np
 import torch
 from torchvision import transforms
-from model.sudoku_resnet import SudokuResNet
+from image_processing.model.sudoku_resnet import SudokuResNet
 
 
 def preprocess_image(image_path):


### PR DESCRIPTION
## 摘要
- 更新 `image_processing/image_to_puzzle.py` 中的 SudokuResNet 导入路径，改为从 `image_processing.model` 包内引用。

## 测试
- `python -m compileall image_processing`


------
https://chatgpt.com/codex/tasks/task_e_68db978f489c8328993a020242a80700